### PR TITLE
Swift support

### DIFF
--- a/config/swift/swift.go
+++ b/config/swift/swift.go
@@ -1,4 +1,69 @@
 package swift
 
+// FileNaming represents the option for file naming of generated sources
+type FileNaming = string
+
+const (
+	// FileNamingName is the option name for file naming
+	FileNamingName = "FileNaming"
+
+	// FullPath is the default and maps the exact path of the .proto file
+	FullPath = FileNaming("FullPath")
+
+	// PathToUnderscores compress the path to use underscores instead of slashes
+	PathToUnderscores = FileNaming("PathToUnderscores")
+
+	// DropPath doesn't include a path and only saves file to the output
+	// directory with the same filename as the .proto file
+	DropPath = FileNaming("DropPath")
+)
+
+// FileNamingValues represents the actual values for file naming
+var FileNamingValues = map[FileNaming]struct{}{
+	FullPath:          struct{}{},
+	PathToUnderscores: struct{}{},
+	DropPath:          struct{}{},
+}
+
+// Visibility represents the option for visibility of generated types
+type Visibility = string
+
+const (
+	// VisibilityName is the option name for generated class visibility
+	VisibilityName = "Visibility"
+
+	// Internal visibility of generated types
+	Internal = Visibility("Internal")
+
+	// Public visibility of generated types
+	Public = Visibility("Public")
+)
+
+// VisibilityValues represents the visibility values that are allowed
+var VisibilityValues = map[Visibility]struct{}{
+	Public:   struct{}{},
+	Internal: struct{}{},
+}
+
+const (
+	// ProtoPathModuleMappingsName is the option name for the swift module file
+	ProtoPathModuleMappingsName = "ProtoPathModuleMappings"
+)
+
+// OptionNames represents the known option names
+var OptionNames = map[string]struct{}{
+	FileNamingName:              struct{}{},
+	VisibilityName:              struct{}{},
+	ProtoPathModuleMappingsName: struct{}{},
+}
+
+// Option represents a configuration option for swift
+type Option struct {
+	Name  string
+	Value string
+}
+
 // Config is configuration specific for the programming language Swift
-type Config struct{}
+type Config struct {
+	Options []Option
+}

--- a/dotfile/ast/ast.go
+++ b/dotfile/ast/ast.go
@@ -181,6 +181,19 @@ func (gps *PathStatement) String() string {
 	return fmt.Sprintf("%s %s", token.KWPath, gps.Type)
 }
 
+// OptionStatement is a statement for language options
+type OptionStatement struct {
+	Token token.Token // token.PATH
+	Name  Expression
+	Value Expression
+}
+
+// TokenLiteral returns the source statement token literal string
+func (os *OptionStatement) TokenLiteral() string { return os.Token.Literal }
+func (os *OptionStatement) String() string {
+	return fmt.Sprintf("%s %s %s", token.KWOption, os.Name, os.Value)
+}
+
 // Identifier describes a value in the configuration
 type Identifier struct {
 	Token token.Token // token.IDENTIFIER

--- a/dotfile/ast/ast_test.go
+++ b/dotfile/ast/ast_test.go
@@ -13,12 +13,15 @@ const (
 	testOutput = "./vendor/protos"
 	testLang   = "go"
 
-	testGoPlugin = "grpc"
+	testGoPlugin    = "grpc"
+	testOptionName  = "WithKey"
+	testOptionValue = "AndValue"
 )
 
 const expectedMinimallyViable = `source github.com/zeeraw/protogen-protos
 language go {
 	plugin grpc
+	option WithKey AndValue
 }
 output ./vendor/protos`
 
@@ -65,6 +68,26 @@ func TestConfigurationFile(t *testing.T) {
 										Type:    token.IDENTIFIER,
 									},
 									Value: testGoPlugin,
+								},
+							},
+							&ast.OptionStatement{
+								Token: token.Token{
+									Literal: token.KWOption,
+									Type:    token.OPTION,
+								},
+								Name: &ast.Identifier{
+									Token: token.Token{
+										Literal: testOptionName,
+										Type:    token.IDENTIFIER,
+									},
+									Value: testOptionName,
+								},
+								Value: &ast.Identifier{
+									Token: token.Token{
+										Literal: testOptionValue,
+										Type:    token.IDENTIFIER,
+									},
+									Value: testOptionValue,
 								},
 							},
 						},

--- a/dotfile/evaluator/evaluator.go
+++ b/dotfile/evaluator/evaluator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/zeeraw/protogen/config/go"
+	"github.com/zeeraw/protogen/config/swift"
 
 	"github.com/zeeraw/protogen/config"
 	"github.com/zeeraw/protogen/dotfile/ast"
@@ -94,6 +95,13 @@ func (e *Evaluator) evalLanguageConfigStatement(stmt *ast.LanguageStatement) (in
 			return e.evalLanguageGoConfigBlock(stmt.Block)
 		}
 		return golang.Config{}, nil
+	case config.Swift:
+		{
+			if stmt.Block != nil {
+				return e.evalLanguageSwiftConfigBlock(stmt.Block)
+			}
+		}
+		return swift.Config{}, nil
 	default:
 		if stmt.Block != nil {
 			err := ErrLanguageNotSupported{lang}

--- a/dotfile/evaluator/swift.go
+++ b/dotfile/evaluator/swift.go
@@ -1,0 +1,38 @@
+package evaluator
+
+import (
+	"log"
+
+	"github.com/zeeraw/protogen/config"
+	"github.com/zeeraw/protogen/config/swift"
+	"github.com/zeeraw/protogen/dotfile/ast"
+)
+
+func (e *Evaluator) evalLanguageSwiftConfigBlock(blk *ast.Block) (swift.Config, error) {
+	log.Printf("evaluating swift config block with %d statements\n", len(blk.Statements))
+	var (
+		cfg     = swift.Config{}
+		options []swift.Option
+	)
+	for _, stmt := range blk.Statements {
+		switch node := stmt.(type) {
+		case *ast.OptionStatement:
+			option, err := e.evalSwiftOption(node)
+			if err != nil {
+				return cfg, err
+			}
+			options = append(options, option)
+		default:
+			return cfg, ErrStatementNotSupported{config.Swift, stmt}
+		}
+	}
+	cfg.Options = options
+	return cfg, nil
+}
+
+func (e *Evaluator) evalSwiftOption(stmt *ast.OptionStatement) (swift.Option, error) {
+	return swift.Option{
+		Name:  stmt.Name.String(),
+		Value: stmt.Value.String(),
+	}, nil
+}

--- a/dotfile/parser/statements.go
+++ b/dotfile/parser/statements.go
@@ -140,3 +140,18 @@ func (p *Parser) parsePluginStatement() ast.Statement {
 	stmt.Name = ast.NewIdentifier(p.Token())
 	return stmt
 }
+
+func (p *Parser) parseOptionStatement() ast.Statement {
+	stmt := &ast.OptionStatement{
+		Token: p.Token(),
+	}
+	if !p.skipWhitespaceUntil(token.IDENTIFIER) {
+		return nil
+	}
+	stmt.Name = ast.NewIdentifier(p.Token())
+	if !p.skipWhitespaceUntil(token.IDENTIFIER) {
+		return nil
+	}
+	stmt.Value = ast.NewIdentifier(p.Token())
+	return stmt
+}

--- a/dotfile/token/token.go
+++ b/dotfile/token/token.go
@@ -41,6 +41,9 @@ const (
 	// PATH defines the keyword for defining the import pathing for go code generation
 	PATH = "PATH"
 
+	// OPTION defines the keyword for specifying options for swift code generation
+	OPTION = "OPTION"
+
 	// Literals
 
 	// VERSION defines a version value
@@ -82,6 +85,9 @@ const (
 
 	// KWPath is the explicit keyword for a go import path
 	KWPath = "path"
+
+	// KWOption is the explicit keyword for a language option
+	KWOption = "option"
 )
 
 var (
@@ -93,6 +99,7 @@ var (
 		KWOutput:   OUTPUT,
 		KWPath:     PATH,
 		KWPlugin:   PLUGIN,
+		KWOption:   OPTION,
 	}
 )
 

--- a/dotfile/token/token_test.go
+++ b/dotfile/token/token_test.go
@@ -15,6 +15,7 @@ func TestLookupIdentifier(t *testing.T) {
 		test.AssertEqual(t, token.Type("OUTPUT"), token.LookupIdentifier("output"))
 		test.AssertEqual(t, token.Type("PATH"), token.LookupIdentifier("path"))
 		test.AssertEqual(t, token.Type("PLUGIN"), token.LookupIdentifier("plugin"))
+		test.AssertEqual(t, token.Type("OPTION"), token.LookupIdentifier("option"))
 	})
 	t.Run("with unknown identifier", func(tt *testing.T) {
 		test.AssertEqual(t, token.Type("IDENTIFIER"), token.LookupIdentifier("some/thing"))

--- a/generator/protoc/protoc.go
+++ b/generator/protoc/protoc.go
@@ -41,6 +41,8 @@ func (p *Protoc) Run(pkg *config.Package, files ...string) error {
 	switch pkg.Language {
 	case config.Go:
 		return p.RunGo(pkg, files...)
+	case config.Swift:
+		return p.RunSwift(pkg, files...)
 	default:
 		return p.RunGeneric(pkg, files...)
 	}

--- a/generator/protoc/swift.go
+++ b/generator/protoc/swift.go
@@ -1,0 +1,58 @@
+package protoc
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/zeeraw/protogen/config"
+	"github.com/zeeraw/protogen/config/swift"
+)
+
+const (
+	swiftOutFlag    = "--swift_out"
+	swiftOptFlag    = "--swift_opt"
+	swiftVisibility = "Visibility"
+	swiftFileNaming = "FileNaming"
+	swiftMappings   = "ProtoPathModuleMappings"
+)
+
+// RunSwift will run generation of a package with Swift code as the output
+func (p *Protoc) RunSwift(pkg *config.Package, files ...string) error {
+	log.Println("protoc running swift")
+	args, err := p.BuildSwift(pkg, files...)
+	if err != nil {
+		return err
+	}
+	return p.Exec(args...)
+}
+
+// BuildSwift will construct the protoc command for a package with Swift code as the output
+func (p *Protoc) BuildSwift(pkg *config.Package, files ...string) ([]string, error) {
+	log.Println("protoc building swift")
+	cfg, ok := pkg.LanguageConfig.(swift.Config)
+	if !ok {
+		return nil, ErrConfigType{pkg.LanguageConfig}
+	}
+	lang := []string{}
+	lang = append(lang, fmt.Sprintf("%s=", swiftOutFlag))
+	lang = append(lang, pkg.Output)
+
+	options := []string{}
+	for _, option := range cfg.Options {
+		options = append(options, buildSwiftOption(option.Name, option.Value))
+	}
+
+	args := []string{}
+	args = append(args, fmt.Sprintf("-I%s", pkg.Root()))
+	for _, option := range options {
+		args = append(args, option)
+	}
+	args = append(args, strings.Join(lang, ""))
+	args = append(args, files...)
+	return args, nil
+}
+
+func buildSwiftOption(option, value string) string {
+	return fmt.Sprintf("%s=%s=%s", swiftOptFlag, option, value)
+}

--- a/generator/protoc/swift_test.go
+++ b/generator/protoc/swift_test.go
@@ -1,4 +1,5 @@
 // +build integration
+// +build darwin
 
 package protoc_test
 

--- a/generator/protoc/swift_test.go
+++ b/generator/protoc/swift_test.go
@@ -1,0 +1,115 @@
+// +build integration
+
+package protoc_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zeeraw/protogen/config"
+	"github.com/zeeraw/protogen/config/swift"
+	"github.com/zeeraw/protogen/test"
+)
+
+func Test_Protoc_BuildSwift(t *testing.T) {
+
+	cases := []struct {
+		name     string
+		pkg      *config.Package
+		files    []string
+		expected []string
+	}{
+		{
+			name: "valid public full path",
+			pkg: &config.Package{
+				Output:   "./tmp",
+				Language: config.Swift,
+				LanguageConfig: swift.Config{
+					Options: []swift.Option{
+						{
+							Name:  "Visibility",
+							Value: "Public",
+						},
+						{
+							Name:  "FileNaming",
+							Value: "FullPath",
+						},
+					},
+				},
+				Source: src,
+			},
+			files: []string{
+				"hello/world.proto",
+			},
+			expected: []string{
+				"--swift_opt=Visibility=Public",
+				"--swift_opt=FileNaming=FullPath",
+				"--swift_out=./tmp",
+				"hello/world.proto",
+			},
+		},
+		{
+			name: "valid internal path to underscores",
+			pkg: &config.Package{
+				Output:   "./tmp",
+				Language: config.Swift,
+				LanguageConfig: swift.Config{
+					Options: []swift.Option{
+						{
+							Name:  "Visibility",
+							Value: "Internal",
+						},
+						{
+							Name:  "FileNaming",
+							Value: "PathToUnderscores",
+						},
+					},
+				},
+				Source: src,
+			},
+			files: []string{
+				"foo/bar.proto",
+				"baz/buz.proto",
+			},
+			expected: []string{
+				"--swift_opt=Visibility=Internal",
+				"--swift_opt=FileNaming=PathToUnderscores",
+				"--swift_out=./tmp",
+				"foo/bar.proto",
+				"baz/buz.proto",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			command, err := p.BuildSwift(c.pkg, c.files...)
+			test.AssertEqual(t, nil, err)
+			test.AssertEqual(t, strings.Join(c.expected, " "), strings.Join(command[1:], " "))
+		})
+	}
+}
+
+func Test_Protoc_RunSwift(t *testing.T) {
+	cfg := &config.Package{
+		Output:   "./tmp",
+		Language: config.Swift,
+		LanguageConfig: swift.Config{
+			Options: []swift.Option{
+				{
+					Name:  "Visibility",
+					Value: "Public",
+				},
+				{
+					Name:  "FileNaming",
+					Value: "FullPath",
+				},
+			},
+		},
+		Source: src,
+	}
+
+	err := p.RunSwift(cfg, "fixtures/fixtures.proto")
+	test.AssertEqual(t, nil, err)
+
+}


### PR DESCRIPTION
This pull request provides configuration support of Swift according to the `protoc-gen-swift` documentation https://github.com/apple/swift-protobuf/blob/master/Documentation/PLUGIN.md#how-to-specify-code-generation-options

The newest addition to the configuration language is the option keyword which allows you to make an option statement.

```protogen
language swift {
  option FileNaming FullPath
}
```

#10